### PR TITLE
allow single line function definitions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,9 @@ module.exports = function(context) {
     var bodyStartLine = body[0].loc.start.line;
     var openBraceLine = context.getTokenBefore(body[0]).loc.start.line;
 
-    if (bodyStartLine - openBraceLine < 2) {
+    if (bodyStartLine !== openBraceLine &&
+        bodyStartLine - openBraceLine < 2) {
+
       context.report(node, 'Missing blank line at beginning of function.');
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,10 +12,14 @@ module.exports = function(context) {
 
     var bodyStartLine = body[0].loc.start.line;
     var openBraceLine = context.getTokenBefore(body[0]).loc.start.line;
+    var closeBraceLine = context.getTokenAfter(body[0]).loc.start.line;
 
-    if (bodyStartLine !== openBraceLine &&
-        bodyStartLine - openBraceLine < 2) {
+    if (body.length === 1 &&
+        openBraceLine === closeBraceLine) {
+      return;
+    }
 
+    if (bodyStartLine - openBraceLine < 2) {
       context.report(node, 'Missing blank line at beginning of function.');
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -98,6 +98,25 @@ describe('ESLint Rule', function() {
     done();
   });
 
+  it('reports an error when function is one line and contains more than one statement', function(done) {
+    var fns = [
+      function fn() { console.log('broken'); return; },
+    ];
+
+    for (var i = 0; i < fns.length; ++i) {
+      var fn = fns[i].toString();
+      var result = linter.verify(fn, linterConfig);
+
+      expect(result).to.be.an.array();
+      expect(result.length).to.equal(1);
+      expect(result[0].ruleId).to.equal(HapiScopeStart.esLintRuleName);
+      expect(result[0].message).to.equal('Missing blank line at beginning of function.');
+      expect(result[0].nodeType).to.equal('FunctionDeclaration');
+    }
+
+    done();
+  });
+
   it('does not report anything when function body is empty', function(done) {
     var fns = [
       function fn() {},

--- a/test/index.js
+++ b/test/index.js
@@ -81,6 +81,23 @@ describe('ESLint Rule', function() {
     done();
   });
 
+  it('does not report anything when function is one line', function(done) {
+    var fns = [
+      function fn() { return; },
+      function fn(foo, bar, baz) { return; }
+    ];
+
+    for (var i = 0; i < fns.length; ++i) {
+      var fn = fns[i].toString();
+      var result = linter.verify(fn, linterConfig);
+
+      expect(result).to.be.an.array();
+      expect(result.length).to.equal(0);
+    }
+
+    done();
+  });
+
   it('does not report anything when function body is empty', function(done) {
     var fns = [
       function fn() {},


### PR DESCRIPTION
this is primarily to cut down on noise in the hapi tests where many handler functions are declared on a single line